### PR TITLE
Docs Updates to fix image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ NPR API Plugin Settings screen
 
 NPR API multiple get settings
 
-![NPR API multiple get settings](docs/assets/img/npr-api-wp-plugin-multiple-get-settings.png)
+![NPR API multiple get settings](docs/assets/img/npr-api-multiple-get-settings.png)
 
 Get NPR Stories link in the dashboard
 

--- a/README.md
+++ b/README.md
@@ -55,23 +55,23 @@ You bet, just visit the NPR Query Generator: [http://www.npr.org/api/queryGenera
 
 NPR API Plugin Settings screen
 
-![NPR API Plugin Settings screen](assets/img/npr-api-wp-plugin-settings.png)
+![NPR API Plugin Settings screen](docs/assets/img/npr-api-wp-plugin-settings.png)
 
 NPR API multiple get settings
 
-![NPR API multiple get settings](assets/img/npr-api-wp-plugin-multiple-get-settings.png)
+![NPR API multiple get settings](docs/assets/img/npr-api-wp-plugin-multiple-get-settings.png)
 
 Get NPR Stories link in the dashboard
 
-![Get NPR Stories link in the dashboard](assets/img/get-npr-stories-link.png)
+![Get NPR Stories link in the dashboard](docs/assets/img/get-npr-stories-link.png)
 
 Getting an NPR Story by Story ID
 
-![Getting NPR Stories by Story ID](assets/img/get-npr-stories-link.png)
+![Getting NPR Stories by Story ID](docs/assets/img/get-npr-stories-link.png)
 
 NPR Stories having got gotten
 
-![NPR Stories having got gotten](assets/img/npr-stories.png)
+![NPR Stories having got gotten](docs/assets/img/npr-stories.png)
 
 
 == Changelog ==

--- a/readme.txt
+++ b/readme.txt
@@ -51,23 +51,23 @@ You bet, just visit the NPR Query Generator: [http://www.npr.org/api/queryGenera
 
 NPR API Plugin Settings screen
 
-![NPR API Plugin Settings screen](assets/img/npr-api-wp-plugin-settings.png)
+![NPR API Plugin Settings screen](docs/assets/img/npr-api-wp-plugin-settings.png)
 
 NPR API multiple get settings
 
-![NPR API multiple get settings](assets/img/npr-api-wp-plugin-multiple-get-settings.png)
+![NPR API multiple get settings](docs/assets/img/npr-api-wp-plugin-multiple-get-settings.png)
 
 Get NPR Stories link in the dashboard
 
-![Get NPR Stories link in the dashboard](assets/img/get-npr-stories-link.png)
+![Get NPR Stories link in the dashboard](docs/assets/img/get-npr-stories-link.png)
 
 Getting an NPR Story by Story ID
 
-![Getting NPR Stories by Story ID](assets/img/get-npr-stories-link.png)
+![Getting NPR Stories by Story ID](docs/assets/img/get-npr-stories-link.png)
 
 NPR Stories having got gotten
 
-![NPR Stories having got gotten](assets/img/npr-stories.png)
+![NPR Stories having got gotten](docs/assets/img/npr-stories.png)
 
 
 == Changelog ==

--- a/readme.txt
+++ b/readme.txt
@@ -55,7 +55,7 @@ NPR API Plugin Settings screen
 
 NPR API multiple get settings
 
-![NPR API multiple get settings](docs/assets/img/npr-api-wp-plugin-multiple-get-settings.png)
+![NPR API multiple get settings](docs/assets/img/npr-api-multiple-get-settings.png)
 
 Get NPR Stories link in the dashboard
 


### PR DESCRIPTION
## What was done:
- Fixed image paths in the repo readme.txt and readme.md files, which were broken after moving the Docs images to a new folder inside /docs/assets/img
- Fixed another broken image due to a filenaming error
## Why?

Completing the plugin docs per https://app.asana.com/0/100231216298059/139466534823465
