### PR TITLE
Correction to pushing.md

### DIFF
--- a/docs/pushing.md
+++ b/docs/pushing.md
@@ -24,7 +24,7 @@ If you don't see these custom fields in the post edit screen, click **Screen Opt
 
 ## Pushing Story Updates to the NPR API
 
-If you edit a story that's previously been pushed to the NPR API, when you update the post it will automatically update the story in the NPR API.
+If you edit a story that's previously been pushed to the NPR API, you can use the **Push to NPR** button in the post editor to update the post in the NPR API.
 
 ## Deleting Posts from the NPR API
 


### PR DESCRIPTION
## What

In pushing.md, revise Pushing Story Updates to the NPR API to explain updates must be pushed manually in the post edit screen.
## Why

I apparently hadn't saved that edit to the file before pushing for the previous PR. Sorry!  This should be the last update to the docs.
